### PR TITLE
kinetis: Add RTC Load Capacitance configuration.

### DIFF
--- a/cpu/kinetis_common/rtc.c
+++ b/cpu/kinetis_common/rtc.c
@@ -61,12 +61,13 @@ void rtc_init(void)
     }
 
     /* Enable RTC oscillator and non-supervisor mode accesses. */
-    rtc->CR = RTC_CR_OSCE_MASK | RTC_CR_SUP_MASK;
+    /* Enable load capacitance as configured by periph_conf.h */
+    rtc->CR = RTC_CR_OSCE_MASK | RTC_CR_SUP_MASK | RTC_LOAD_CAP_BITS;
 
     /* Clear TAF by writing TAR. */
     rtc->TAR = 0xffffff42;
 
-    /* Disale all RTC interrupts. */
+    /* Disable all RTC interrupts. */
     rtc->IER = 0;
 
     rtc_poweron();


### PR DESCRIPTION
Add support for configuring the CPU built-in load capacitance for the RTC crystal via `periph_conf.h`.

Set RTC_LOAD_CAP_BITS in `periph_conf.h`

Example:

    /* enable 12pF load capacitance, might need adjusting.. */
    #define RTC_LOAD_CAP_BITS   (RTC_CR_SC8P_MASK | RTC_CR_SC4P_MASK)

Fixed a typo in a comment nearby as well..