### PR TITLE
Kinetis RNGB implementation

### DIFF
--- a/cpu/kinetis_common/random_rnga.c
+++ b/cpu/kinetis_common/random_rnga.c
@@ -28,6 +28,8 @@
 #include "periph_conf.h"
 
 #if RANDOM_NUMOF
+#ifdef KINETIS_RNGA
+
 
 typedef struct RNG_MemMap {
     uint32_t CR;
@@ -66,15 +68,15 @@ int random_read(char *buf, unsigned int num)
     int count = 0;
 
     /* self-seeding */
-    while (!(RNGA->SR & RNGA_SR_OREG_LVL_MASK));
+    while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK));
 
-    RNGA->ER = RNGA->OR ^ (uint32_t)buf;
+    KINETIS_RNGA->ER = KINETIS_RNGA->OR ^ (uint32_t)buf;
 
     while (count < num) {
         /* wait for random data to be ready to read */
-        while (!(RNGA->SR & RNGA_SR_OREG_LVL_MASK));
+        while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK));
 
-        tmp = RNGA->OR;
+        tmp = KINETIS_RNGA->OR;
 
         /* copy data into result vector */
         for (int i = 0; i < 4 && count < num; i++) {
@@ -89,12 +91,12 @@ int random_read(char *buf, unsigned int num)
 void random_poweron(void)
 {
     RANDOM_CLKEN();
-    RNGA->CR = RNGA_CR_INTM_MASK | RNGA_CR_HA_MASK | RNGA_CR_GO_MASK;
+    KINETIS_RNGA->CR = RNG_CR_INTM_MASK | RNG_CR_HA_MASK | RNG_CR_GO_MASK;
 }
 
 void random_poweroff(void)
 {
-    RNGA->CR = 0;
+    KINETIS_RNGA->CR = 0;
     RANDOM_CLKDIS();
 }
 
@@ -104,4 +106,5 @@ void isr_rng(void)
 }
 */
 
+#endif /* KINETIS_RNGA */
 #endif /* RANDOM_NUMOF */

--- a/cpu/kinetis_common/random_rngb.c
+++ b/cpu/kinetis_common/random_rngb.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis_common
+ * @{
+ *
+ * @file
+ * @brief       Low-level random number generator driver implementation.
+ *              Driver for Freescale's RNGB module. RNGB generates data that
+ *              looks random. Reference Manual recommends to use the RNGB as entropy
+ *              source.
+ *
+ * @author      Joakim Gebart <joakim.gebart@eistec.se> (adaption for Freescale's RNGB)
+ * @author      Johann Fischer <j.fischer@phytec.de> (adaption for Freescale's RNGA)
+ * @author      Hauke Petersen <mail@haukepetersen.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/random.h"
+#include "periph_conf.h"
+
+#if RANDOM_NUMOF
+#ifdef KINETIS_RNGB
+
+
+void random_init(void)
+{
+    random_poweron();
+}
+
+int random_read(char *buf, unsigned int num)
+{
+    int count = 0;
+
+    while (count < num) {
+        uint32_t tmp;
+        /* wait for random data to be ready to read */
+        while (!(KINETIS_RNGB->SR & RNG_SR_FIFO_LVL_MASK));
+
+        tmp = KINETIS_RNGB->OUT;
+
+        /* copy data into result vector */
+        for (int i = 0; i < 4 && count < num; i++) {
+            buf[count++] = (char)tmp;
+            tmp = tmp >> 8;
+        }
+    }
+
+    return count;
+}
+
+void random_poweron(void)
+{
+    RANDOM_CLKEN();
+    if ((KINETIS_RNGB->VER & RNG_VER_TYPE_MASK) != 0b0001)
+    {
+        /* Wrong type of RNG */
+        /* TODO: Handle */
+    }
+
+    /* Software reset, bit is self-clearing */
+    BITBAND_REG(KINETIS_RNGB->CMD, RNG_CMD_SR_SHIFT) = 1;
+    /* Set up automatic reseed */
+    KINETIS_RNGB->CR = RNG_CR_AR_MASK | RNG_CR_MASKERR_MASK | RNG_CR_MASKDONE_MASK;
+}
+
+void random_poweroff(void)
+{
+    KINETIS_RNGB->CR = 0;
+    RANDOM_CLKDIS();
+}
+
+/*
+void isr_rng(void)
+{
+}
+*/
+
+#endif /* KINETIS_RNGB */
+#endif /* RANDOM_NUMOF */


### PR DESCRIPTION
A basic RNGB implementation using automatic seeding.

Example `periph_conf.h` excerpt:

    /**
     * @name Random Number Generator configuration
     * @{
     */
    #define RANDOM_NUMOF            (1U)
    #if K60_CPU_REV == 1
    #define KINETIS_RNGB (RNG)
    #define RANDOM_CLKEN()          (BITBAND_REG(SIM->SCGC3, SIM_SCGC3_RNGB_SHIFT) = 1)
    #define RANDOM_CLKDIS()         (BITBAND_REG(SIM->SCGC3, SIM_SCGC3_RNGB_SHIFT) = 0)
    #elif K60_CPU_REV == 2
    #define KINETIS_RNGA (RNG)
    #define RANDOM_CLKEN()          (BITBAND_REG(SIM->SCGC3, SIM_SCGC3_RNGA_SHIFT) = 1)
    #define RANDOM_CLKDIS()         (BITBAND_REG(SIM->SCGC3, SIM_SCGC3_RNGA_SHIFT) = 0)
    #endif
    /** @} */

or similar depending on what CPU is being targeted.
RNGB driver is only built if `KINETIS_RNGB` is set, RNGA driver is only built if `KINETIS_RNGA` is set. It is not possible to build both at the same time due to symbol conflicts.